### PR TITLE
add  phantomjs

### DIFF
--- a/thridparty/jenkins-inbound-agent/src/main/docker/Dockerfile
+++ b/thridparty/jenkins-inbound-agent/src/main/docker/Dockerfile
@@ -46,7 +46,8 @@ RUN echo “dash dash/sh boolean false” | debconf-set-selections
 RUN DEBIAN_FRONTEND=noninteractive dpkg-reconfigure dash
 
 # add phantomjs
-ADD phantomjs-2.1.1-linux-x86_64.tar.bz2 /tmp/phantomjs/
+RUN mkdir /tmp/phantomjs/
+COPY phantomjs-2.1.1-linux-x86_64.tar.bz2 /tmp/phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2
 #华为obs安装
 RUN mkdir -p /temp
 ADD obsutil /temp/obsutil

--- a/thridparty/jenkins-inbound-agent/src/main/docker/Dockerfile
+++ b/thridparty/jenkins-inbound-agent/src/main/docker/Dockerfile
@@ -45,6 +45,8 @@ RUN cat /proc/version
 RUN echo “dash dash/sh boolean false” | debconf-set-selections
 RUN DEBIAN_FRONTEND=noninteractive dpkg-reconfigure dash
 
+# add phantomjs
+ADD phantomjs-2.1.1-linux-x86_64.tar.bz2 /tmp/phantomjs/
 #华为obs安装
 RUN mkdir -p /temp
 ADD obsutil /temp/obsutil


### PR DESCRIPTION
Put the phantom js package into the jenkins inbound java image to improve the speed of npm compilation

将phantomjs包放入jenkins-inbound-java镜像中，提升npm编译的速度